### PR TITLE
[59 obs] Fixing random seed for reproducibility

### DIFF
--- a/gym_multigrid/envs/ctf.py
+++ b/gym_multigrid/envs/ctf.py
@@ -314,15 +314,20 @@ class Ctf1v1Env(MultiGridEnv):
 
         self.place_agent(
             self.agents[0],
-            pos=self.blue_territory[np.random.randint(0, len(self.blue_territory))],
+            pos=self.blue_territory[self.np_random.integers(0, len(self.blue_territory))],
         )
         self.place_agent(
             self.agents[1],
-            pos=self.red_territory[np.random.randint(0, len(self.red_territory))],
+            pos=self.red_territory[self.np_random.integers(0, len(self.red_territory))],
         )
 
-    def reset(self, seed=None) -> tuple[Observation, dict[str, float]]:
-        super().reset(seed)
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict | None = None,
+    ) -> tuple[Observation, dict[str, float]]:
+        super().reset(seed=seed)
         self._is_red_agent_defeated: bool = False
 
         assert self.agents[0].pos is not None
@@ -583,18 +588,18 @@ class Ctf1v1Env(MultiGridEnv):
 
             match (blue_agent_in_blue_territory, red_agent_in_red_territory):
                 case (True, True):
-                    blue_win = np.random.choice([True, False])
+                    blue_win = self.np_random.choice([True, False])
                 case (True, False):
-                    blue_win = np.random.choice(
+                    blue_win = self.np_random.choice(
                         [True, False], p=[self.randomness, 1 - self.randomness]
                     )
                 case (False, True):
-                    blue_win = np.random.choice(
+                    blue_win = self.np_random.choice(
                         [True, False], p=[1 - self.randomness, self.randomness]
                     )
 
                 case (False, False):
-                    blue_win = np.random.choice([True, False])
+                    blue_win = self.np_random.choice([True, False])
 
                 case (_, _):
                     raise ValueError(

--- a/gym_multigrid/envs/ctf.py
+++ b/gym_multigrid/envs/ctf.py
@@ -124,9 +124,9 @@ class Ctf1v1Env(MultiGridEnv):
         self.obstacle_penalty: Final[float] = obstacle_penalty_ratio * flag_reward
         self.step_penalty: Final[float] = step_penalty_ratio * flag_reward
 
-        self.observation_option: Final[
-            Literal["positional", "map", "flattened"]
-        ] = observation_option
+        self.observation_option: Final[Literal["positional", "map", "flattened"]] = (
+            observation_option
+        )
         self.observation_scaling: Final[float] = observation_scaling
 
         partial_obs: bool = False
@@ -314,7 +314,9 @@ class Ctf1v1Env(MultiGridEnv):
 
         self.place_agent(
             self.agents[0],
-            pos=self.blue_territory[self.np_random.integers(0, len(self.blue_territory))],
+            pos=self.blue_territory[
+                self.np_random.integers(0, len(self.blue_territory))
+            ],
         )
         self.place_agent(
             self.agents[1],
@@ -403,9 +405,9 @@ class Ctf1v1Env(MultiGridEnv):
         assert self.agents[0].pos is not None
         assert self.agents[1].pos is not None
 
-        encoded_map[
-            self.agents[0].pos[0], self.agents[0].pos[1]
-        ] = self.world.OBJECT_TO_IDX["blue_agent"]
+        encoded_map[self.agents[0].pos[0], self.agents[0].pos[1]] = (
+            self.world.OBJECT_TO_IDX["blue_agent"]
+        )
 
         encoded_map[self.agents[1].pos[0], self.agents[1].pos[1]] = (
             self.world.OBJECT_TO_IDX["red_agent"]

--- a/gym_multigrid/envs/maze.py
+++ b/gym_multigrid/envs/maze.py
@@ -241,7 +241,7 @@ class MazeSingleAgentEnv(MultiGridEnv):
         )
 
     def reset(self, seed=None) -> tuple[Observation, dict[str, float]]:
-        super().reset(seed)
+        super().reset(seed=seed)
 
         agent: Agent = self.agents[0]
 

--- a/gym_multigrid/multigrid.py
+++ b/gym_multigrid/multigrid.py
@@ -112,7 +112,13 @@ class MultiGridEnv(gym.Env):
 
         return observation_space
 
-    def reset(self, seed: int | None = None):
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict | None = None,
+    ):
+
         super().reset(seed=seed)
         # Generate a new random grid at the start of each episode
         # To keep the same grid for each episode, call env.seed() with

--- a/tests/test_ctf.py
+++ b/tests/test_ctf.py
@@ -18,3 +18,16 @@ def test_ctf() -> None:
         env.render()
         if terminated or truncated:
             break
+
+# TODO: might be good idea to include seeding test for other environments
+def test_ctf_random_seeding() -> None:
+    map_path: str = "tests/assets/board.txt"
+    env = Ctf1v1Env(
+        map_path=map_path, render_mode="human", observation_option="flattened"
+    )
+    env.reset(seed=1)
+    array1 = env.np_random.random(10)
+    env.reset(seed=1)
+    array2 = env.np_random.random(10)
+
+    np.testing.assert_allclose(array1, array2)

--- a/tests/test_ctf.py
+++ b/tests/test_ctf.py
@@ -19,6 +19,7 @@ def test_ctf() -> None:
         if terminated or truncated:
             break
 
+
 # TODO: might be good idea to include seeding test for other environments
 def test_ctf_random_seeding() -> None:
     map_path: str = "tests/assets/board.txt"


### PR DESCRIPTION
## Changes

- Previously, the `ctf` environment was using global `numpy.random` which is not threadsafe and has potential issues in reproducibility. The change uses the current `openai-gym` standard of fixing seed: [site](https://github.com/Farama-Foundation/Gymnasium/blob/144feb865a30dfb0a486c33f2012ed669a30b38c/gymnasium/core.py#L112)
  - `np.random` -> `self.np_random`
- Added unit test to check if the environment random-generator reset properly.
- `black` formatting for pep8

## Issue ticket number and link

- Partially address #44 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Formatting
- [x] unit-test
  - [x] pass the test