### PR TITLE
feat: Retrieve agents initial positions

### DIFF
--- a/gym_multigrid/envs/ctf.py
+++ b/gym_multigrid/envs/ctf.py
@@ -825,6 +825,8 @@ class CtfMvNEnv(MultiGridEnv):
                 else -1
             ),
             "red_actions": [0 for _ in range(self.num_red_agents)],
+            "blue_init_positions": [0 for traj in self.blue_traj],
+            "red_init_positions": [0 for traj in self.red_traj]
         } | self.ep_game_stats
         return info
 
@@ -948,6 +950,9 @@ class CtfMvNEnv(MultiGridEnv):
             assert type(red_agent) is PolicyAgent
             red_action: int = red_agent.policy.act(self._get_dict_obs(), red_agent.pos)
             red_actions.append(red_action)
+
+        blue_init_positions: list[Position] = [list(traj[0]) for traj in self.blue_traj]
+        red_init_positions: list[Position] = [list(traj[0]) for traj in self.blue_traj]
 
         # Just in case NN outputs are, for some reason, not discrete.
         rounded_blue_actions: NDArray[np.int_] = np.round(blue_actions).astype(np.int_)
@@ -1085,6 +1090,10 @@ class CtfMvNEnv(MultiGridEnv):
 
         # Add red agent actions to the info dictionary.
         info["red_actions"] = red_actions
+
+        # Adding blue and red agents initial positions into info dictionary
+        info["blue_init_positions"] = blue_init_positions
+        info["red_init_positions"] = red_init_positions
 
         if terminated or truncated:
             self.ep_game_stats = self.game_stats

--- a/gym_multigrid/envs/ctf.py
+++ b/gym_multigrid/envs/ctf.py
@@ -825,8 +825,8 @@ class CtfMvNEnv(MultiGridEnv):
                 else -1
             ),
             "red_actions": [0 for _ in range(self.num_red_agents)],
-            "blue_init_positions": [0 for traj in self.blue_traj],
-            "red_init_positions": [0 for traj in self.red_traj]
+            "blue_init_positions": [(0,0) for traj in self.blue_traj],
+            "red_init_positions": [(0,0) for traj in self.red_traj]
         } | self.ep_game_stats
         return info
 
@@ -951,8 +951,8 @@ class CtfMvNEnv(MultiGridEnv):
             red_action: int = red_agent.policy.act(self._get_dict_obs(), red_agent.pos)
             red_actions.append(red_action)
 
-        blue_init_positions: list[Position] = [list(traj[0]) for traj in self.blue_traj]
-        red_init_positions: list[Position] = [list(traj[0]) for traj in self.blue_traj]
+        blue_init_positions: list[Position] = [tuple(traj[0]) for traj in self.blue_traj]
+        red_init_positions: list[Position] = [tuple(traj[0]) for traj in self.blue_traj]
 
         # Just in case NN outputs are, for some reason, not discrete.
         rounded_blue_actions: NDArray[np.int_] = np.round(blue_actions).astype(np.int_)


### PR DESCRIPTION
Modified ctf.py to retrieve blue and red agents actions through the info dictionary.

Issue: #130 

Note: VS Code committed through @hamidosooli 's account. Sorry! 
