### PR TITLE
Fix border appending logic in heuristic.py

### DIFF
--- a/gym_multigrid/policy/ctf/heuristic.py
+++ b/gym_multigrid/policy/ctf/heuristic.py
@@ -510,7 +510,7 @@ class PatrolPolicy(DestinationPolicy):
             for dir in directions:
                 new_loc: Position = (loc[0] + dir[0], loc[1] + dir[1])
                 if position_in_positions(new_loc, opponent_territory + obstacle):
-                    border.append(new_loc)
+                    border.append(loc)
                     break
                 else:
                     pass


### PR DESCRIPTION
PatrolPolicy.locate_border() appends new_loc (neighbor cell, out-border) instead of loc (in-border). 
With new_loc, 6 border cells were opponent territory, 4 border cells were obstacle. 
With loc, 10 border cells are red territory.